### PR TITLE
feat: implementa mapeamento do histórico da questão

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,14 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
@@ -48,6 +56,13 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!--    Utilidades    -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.32</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 
@@ -84,6 +99,13 @@
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
                     </systemPropertyVariables>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.32</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,10 @@
             <version>1.5.5.Final</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,14 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -63,6 +71,21 @@
             <artifactId>lombok</artifactId>
             <version>1.18.32</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -104,6 +127,11 @@
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                             <version>1.18.32</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,24 @@
+#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+version: "1.0"
+#Specify inspection profile for code analysis
+profile:
+  name: qodana.starter
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+projectJDK: 21 #(Applied in CI/CD pipeline)
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
+#Specify Qodana linter for analysis (Applied in CI/CD pipeline)
+linter: jetbrains/qodana-jvm:latest

--- a/src/main/java/br/usp/esimulados/exception/ExceptionMapper.java
+++ b/src/main/java/br/usp/esimulados/exception/ExceptionMapper.java
@@ -1,0 +1,20 @@
+package br.usp.esimulados.exception;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+import java.util.Map;
+
+@ApplicationScoped
+public class ExceptionMapper {
+
+    @ServerExceptionMapper
+    public RestResponse<Object> mapException(ObjectNotFoundException objectNotFoundException) {
+        Map<String, String> body = Map.of(
+                "message", objectNotFoundException.getMessage()
+        );
+        return RestResponse.status(Response.Status.NOT_FOUND, body);
+    }
+}

--- a/src/main/java/br/usp/esimulados/exception/ObjectNotFoundException.java
+++ b/src/main/java/br/usp/esimulados/exception/ObjectNotFoundException.java
@@ -1,0 +1,11 @@
+package br.usp.esimulados.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class ObjectNotFoundException extends RuntimeException {
+    public ObjectNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/usp/esimulados/model/exam/Answer.java
+++ b/src/main/java/br/usp/esimulados/model/exam/Answer.java
@@ -1,0 +1,9 @@
+package br.usp.esimulados.model.exam;
+
+public record Answer(
+    Long questionId,
+    Character alternativeId,
+    boolean correct,
+    String alternativeContent,
+    String correctAnswerContent
+) { }

--- a/src/main/java/br/usp/esimulados/model/exam/Exam.java
+++ b/src/main/java/br/usp/esimulados/model/exam/Exam.java
@@ -1,0 +1,46 @@
+package br.usp.esimulados.model.exam;
+
+import br.usp.esimulados.model.questions.Question;
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "exams")
+@RegisterForReflection
+public class Exam extends PanacheEntity {
+
+    @OneToMany
+    private List<Question> questions;
+    private String author;
+    private String authorId;
+
+    // Cabeçalho
+    private String name;
+    private String description;
+    private String imageUrl;
+
+    // filtros
+    @ElementCollection
+    private List<String> tags;
+    private String category;
+    private String subCategory;
+
+    // Controle interno
+    private UUID uuid = UUID.randomUUID();
+    private int version = 0;
+    private boolean active = true;
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+}

--- a/src/main/java/br/usp/esimulados/model/exam/ExamAttempt.java
+++ b/src/main/java/br/usp/esimulados/model/exam/ExamAttempt.java
@@ -1,0 +1,37 @@
+package br.usp.esimulados.model.exam;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "exam_attempts")
+public class ExamAttempt extends PanacheEntity {
+    private Long examId;
+    private Long userId;
+    private int examVersion;
+    private int totalQuestions;
+    private int totalCorrectAnswers;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "answers", columnDefinition = "jsonb"/*, insertable = false, updatable = false*/)
+    private List<Answer> answers;
+
+    private boolean active;
+    private UUID uuid = UUID.randomUUID();
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/br/usp/esimulados/model/exam/dto/AttemptExamDTO.java
+++ b/src/main/java/br/usp/esimulados/model/exam/dto/AttemptExamDTO.java
@@ -1,0 +1,14 @@
+package br.usp.esimulados.model.exam.dto;
+
+import br.usp.esimulados.model.exam.Answer;
+
+import java.util.List;
+
+public record AttemptExamDTO(
+    Long examId,
+    Long userId,
+    int examVersion,
+    int totalQuestions,
+    int totalCorrectAnswers,
+    List<Answer> answers
+) { }

--- a/src/main/java/br/usp/esimulados/model/exam/dto/CreateExamDTO.java
+++ b/src/main/java/br/usp/esimulados/model/exam/dto/CreateExamDTO.java
@@ -1,0 +1,19 @@
+package br.usp.esimulados.model.exam.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CreateExamDTO(
+    @NotEmpty(message = "É necessário adicionar ao menos uma questão ao simulado.")
+    List<String> questionIds,
+    List<String> tags,
+    @NotNull String category,
+    @NotNull String subCategory,
+    @NotNull String author,
+    @NotNull String authorId,
+    @NotNull String name,
+    @NotNull String description,
+    @NotNull String imageUrl
+) { }

--- a/src/main/java/br/usp/esimulados/model/questions/Comment.java
+++ b/src/main/java/br/usp/esimulados/model/questions/Comment.java
@@ -1,0 +1,25 @@
+package br.usp.esimulados.model.questions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Comment implements Serializable {
+    private String content;
+    private String author;
+    private String authorId;
+
+    private UUID uuid = UUID.randomUUID();
+    private boolean active = true;
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/br/usp/esimulados/model/questions/Question.java
+++ b/src/main/java/br/usp/esimulados/model/questions/Question.java
@@ -1,0 +1,51 @@
+package br.usp.esimulados.model.questions;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "questions")
+public class Question extends PanacheEntity {
+
+    private String statement; // enunciado
+    private String explanation;
+
+    private String topic;
+    private String subTopic;
+    private int year;
+    private String source;
+    private String sourceUrl;
+    private String authorId;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "tags", columnDefinition = "jsonb"/*, insertable = false, updatable = false*/)
+    private List<String> tags;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "comments", columnDefinition = "jsonb"/*, insertable = false, updatable = false*/)
+    private List<Comment> comments;
+
+    private QuestionDifficulty difficulty; // EASY, MEDIUM, HARD
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "alternatives", columnDefinition = "jsonb"/*, insertable = false, updatable = false*/)
+    private List<QuestionAlternative> alternatives;
+
+    private UUID uuid = UUID.randomUUID();
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/br/usp/esimulados/model/questions/Question.java
+++ b/src/main/java/br/usp/esimulados/model/questions/Question.java
@@ -39,11 +39,15 @@ public class Question extends PanacheEntity {
     @Column(name = "comments", columnDefinition = "jsonb"/*, insertable = false, updatable = false*/)
     private List<Comment> comments;
 
-    private QuestionDifficulty difficulty; // EASY, MEDIUM, HARD
+    private QuestionDifficulty questionDifficulty; // EASY, MEDIUM, HARD
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "alternatives", columnDefinition = "jsonb"/*, insertable = false, updatable = false*/)
     private List<QuestionAlternative> alternatives;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "questionHistory", columnDefinition = "jsonb")
+    private QuestionHistory questionHistory = new QuestionHistory();
 
     private UUID uuid = UUID.randomUUID();
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/src/main/java/br/usp/esimulados/model/questions/QuestionAlternative.java
+++ b/src/main/java/br/usp/esimulados/model/questions/QuestionAlternative.java
@@ -1,0 +1,11 @@
+package br.usp.esimulados.model.questions;
+
+import java.util.List;
+import java.util.UUID;
+
+public record QuestionAlternative(
+    List<String> imageUrls,
+    String content,
+    boolean correct,
+    UUID uuid
+) { }

--- a/src/main/java/br/usp/esimulados/model/questions/QuestionDifficulty.java
+++ b/src/main/java/br/usp/esimulados/model/questions/QuestionDifficulty.java
@@ -1,5 +1,7 @@
 package br.usp.esimulados.model.questions;
 
 public enum QuestionDifficulty {
-    EASY, MEDIUM, HARD
+    EASY,
+    MEDIUM,
+    HARD
 }

--- a/src/main/java/br/usp/esimulados/model/questions/QuestionDifficulty.java
+++ b/src/main/java/br/usp/esimulados/model/questions/QuestionDifficulty.java
@@ -1,0 +1,5 @@
+package br.usp.esimulados.model.questions;
+
+public enum QuestionDifficulty {
+    EASY, MEDIUM, HARD
+}

--- a/src/main/java/br/usp/esimulados/model/questions/QuestionHistory.java
+++ b/src/main/java/br/usp/esimulados/model/questions/QuestionHistory.java
@@ -8,20 +8,18 @@ import lombok.Setter;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class QuestionAlternative implements Serializable {
+public class QuestionHistory implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private List<String> imageUrls;
-    private String content;
-    private boolean correct;
+    private Long attemptCount = 0L;
+    private Long correctAnswersCount = 0L;
 
     private UUID uuid = UUID.randomUUID();
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/src/main/java/br/usp/esimulados/model/questions/dto/CreateCommentDTO.java
+++ b/src/main/java/br/usp/esimulados/model/questions/dto/CreateCommentDTO.java
@@ -1,0 +1,7 @@
+package br.usp.esimulados.model.questions.dto;
+
+public record CreateCommentDTO(
+    String content,
+    String author,
+    String authorId
+) { }

--- a/src/main/java/br/usp/esimulados/model/questions/dto/CreateQuestionAlternativeDTO.java
+++ b/src/main/java/br/usp/esimulados/model/questions/dto/CreateQuestionAlternativeDTO.java
@@ -1,0 +1,11 @@
+package br.usp.esimulados.model.questions.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CreateQuestionAlternativeDTO(
+    List<String> imageUrls,
+    @NotNull String content,
+    @NotNull boolean correct
+) { }

--- a/src/main/java/br/usp/esimulados/model/questions/dto/CreateQuestionDTO.java
+++ b/src/main/java/br/usp/esimulados/model/questions/dto/CreateQuestionDTO.java
@@ -1,0 +1,20 @@
+package br.usp.esimulados.model.questions.dto;
+
+import br.usp.esimulados.model.questions.QuestionDifficulty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CreateQuestionDTO(
+    @NotNull String statement,
+    String explanation,
+    @NotNull String topic,
+    @NotNull String subTopic,
+    int year,
+    String source,
+    String sourceUrl,
+    @NotNull String authorId,
+    @NotNull List<String> tags,
+    @NotNull QuestionDifficulty questionDifficulty,
+    @NotNull List<CreateQuestionAlternativeDTO> questionAlternatives
+) { }

--- a/src/main/java/br/usp/esimulados/model/user/User.java
+++ b/src/main/java/br/usp/esimulados/model/user/User.java
@@ -1,0 +1,30 @@
+package br.usp.esimulados.model.user;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "users")
+public class User extends PanacheEntity {
+    // google
+    private String name;
+    private String email;
+    private String imageUrl;
+
+    private UserRole role;
+    private UUID organizationId;
+    private boolean active;
+
+    private List<String> favoriteExams;
+
+}

--- a/src/main/java/br/usp/esimulados/model/user/UserRole.java
+++ b/src/main/java/br/usp/esimulados/model/user/UserRole.java
@@ -1,0 +1,5 @@
+package br.usp.esimulados.model.user;
+
+public enum UserRole {
+    TEACHER, STUDENT, ASSISTANT
+}

--- a/src/main/java/br/usp/esimulados/resource/ExamsAttemptsResource.java
+++ b/src/main/java/br/usp/esimulados/resource/ExamsAttemptsResource.java
@@ -1,0 +1,57 @@
+package br.usp.esimulados.resource;
+
+import br.usp.esimulados.model.exam.Exam;
+import br.usp.esimulados.model.exam.dto.AttemptExamDTO;
+import br.usp.esimulados.service.ExamAttemptsService;
+import io.vertx.core.http.HttpServerRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Slf4j
+@ApplicationScoped
+@Tag(name = "Tentativas")
+@Path("/exams_attempts")
+public class ExamsAttemptsResource {
+
+    @Inject
+    ExamAttemptsService examAttemptsService;
+
+    @Inject
+    HttpServerRequest request;
+
+    @Transactional
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Tentativa")
+    @APIResponse(description = "Simulado criado",
+            responseCode = "200",
+            content = { @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = Exam.class,
+                            type = SchemaType.OBJECT
+                    ))
+            })
+    public Response add(
+           @Valid @RequestBody(description = "Simulado a ser criado") AttemptExamDTO createExam
+    ) {
+        log.info("Request: {}", request);
+        return Response.ok(examAttemptsService.add(createExam)).build();
+    }
+
+}

--- a/src/main/java/br/usp/esimulados/resource/ExamsResource.java
+++ b/src/main/java/br/usp/esimulados/resource/ExamsResource.java
@@ -1,7 +1,7 @@
 package br.usp.esimulados.resource;
 
-import br.usp.esimulados.model.exam.CreateExam;
 import br.usp.esimulados.model.exam.Exam;
+import br.usp.esimulados.model.exam.dto.CreateExamDTO;
 import br.usp.esimulados.service.ExamsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -44,7 +44,7 @@ public class ExamsResource {
                     ))
             })
     public Response createExam(
-           @Valid @RequestBody(description = "Simulado a ser criado") CreateExam createExam
+           @Valid @RequestBody(description = "Simulado a ser criado") CreateExamDTO createExam
     ) {
         return Response.ok(examsService.createExam(createExam)).build();
     }

--- a/src/main/java/br/usp/esimulados/resource/ExamsResource.java
+++ b/src/main/java/br/usp/esimulados/resource/ExamsResource.java
@@ -1,0 +1,52 @@
+package br.usp.esimulados.resource;
+
+import br.usp.esimulados.model.exam.CreateExam;
+import br.usp.esimulados.model.exam.Exam;
+import br.usp.esimulados.service.ExamsService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Slf4j
+@Path("/exams")
+@ApplicationScoped
+@Tag(name = "Exams")
+public class ExamsResource {
+
+    @Inject
+    ExamsService examsService;
+
+    @Transactional
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Criar simulado")
+    @APIResponse(description = "Simulado criado",
+            responseCode = "200",
+            content = { @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = Exam.class,
+                            type = SchemaType.OBJECT
+                    ))
+            })
+    public Response createExam(
+           @Valid @RequestBody(description = "Simulado a ser criado") CreateExam createExam
+    ) {
+        return Response.ok(examsService.createExam(createExam)).build();
+    }
+
+}

--- a/src/main/java/br/usp/esimulados/resource/QuestionsResource.java
+++ b/src/main/java/br/usp/esimulados/resource/QuestionsResource.java
@@ -35,8 +35,8 @@ public class QuestionsResource {
     @Inject
     HttpServerRequest request;
 
-    @Transactional
     @POST
+    @Transactional
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Criar questão")
     @APIResponse(description = "Questão criada",
@@ -49,7 +49,7 @@ public class QuestionsResource {
                     ))
             })
     public Response createQuestion(
-           @Valid @RequestBody(description = "Lista de presentes a serem criados") CreateQuestionDTO createQuestion
+           @Valid @RequestBody(description = "Questão a ser criada") CreateQuestionDTO createQuestion
     ) {
         log.info("Request: {}", request.toString());
         return Response.ok(questionsService.createQuestion(createQuestion)).build();

--- a/src/main/java/br/usp/esimulados/resource/QuestionsResource.java
+++ b/src/main/java/br/usp/esimulados/resource/QuestionsResource.java
@@ -1,8 +1,8 @@
 package br.usp.esimulados.resource;
 
-import br.usp.esimulados.model.questions.CreateComment;
-import br.usp.esimulados.model.questions.CreateQuestion;
 import br.usp.esimulados.model.questions.Question;
+import br.usp.esimulados.model.questions.dto.CreateCommentDTO;
+import br.usp.esimulados.model.questions.dto.CreateQuestionDTO;
 import br.usp.esimulados.service.QuestionsService;
 import io.vertx.core.http.HttpServerRequest;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -49,7 +49,7 @@ public class QuestionsResource {
                     ))
             })
     public Response createQuestion(
-           @Valid @RequestBody(description = "Lista de presentes a serem criados") CreateQuestion createQuestion
+           @Valid @RequestBody(description = "Lista de presentes a serem criados") CreateQuestionDTO createQuestion
     ) {
         log.info("Request: {}", request.toString());
         return Response.ok(questionsService.createQuestion(createQuestion)).build();
@@ -61,7 +61,7 @@ public class QuestionsResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response addComment(
             @PathParam("id") Long questionId,
-            @RequestBody(description = "Comentário") CreateComment comment
+            @RequestBody(description = "Comentário") CreateCommentDTO comment
     ) {
         this.questionsService.addComment(questionId, comment);
         return Response.ok().build();

--- a/src/main/java/br/usp/esimulados/resource/QuestionsResource.java
+++ b/src/main/java/br/usp/esimulados/resource/QuestionsResource.java
@@ -1,0 +1,82 @@
+package br.usp.esimulados.resource;
+
+import br.usp.esimulados.model.questions.CreateComment;
+import br.usp.esimulados.model.questions.CreateQuestion;
+import br.usp.esimulados.model.questions.Question;
+import br.usp.esimulados.service.QuestionsService;
+import io.vertx.core.http.HttpServerRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.UUID;
+
+@Slf4j
+@Tag(name = "Questions")
+@Path("/questions")
+@ApplicationScoped
+public class QuestionsResource {
+
+    @Inject
+    QuestionsService questionsService;
+
+    @Inject
+    HttpServerRequest request;
+
+    @Transactional
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Criar questão")
+    @APIResponse(description = "Questão criada",
+            responseCode = "200",
+            content = { @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = Question.class,
+                            type = SchemaType.OBJECT
+                    ))
+            })
+    public Response createQuestion(
+           @Valid @RequestBody(description = "Lista de presentes a serem criados") CreateQuestion createQuestion
+    ) {
+        log.info("Request: {}", request.toString());
+        return Response.ok(questionsService.createQuestion(createQuestion)).build();
+    }
+
+    @POST
+    @Transactional
+    @Path("/{id}/comments")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response addComment(
+            @PathParam("id") Long questionId,
+            @RequestBody(description = "Comentário") CreateComment comment
+    ) {
+        this.questionsService.addComment(questionId, comment);
+        return Response.ok().build();
+    }
+
+    @DELETE
+    @Transactional
+    @Path("/{id}/comments/{commentId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response addComment(
+            @PathParam("id") Long questionId,
+            @PathParam("commentId") UUID commentId
+    ) {
+        this.questionsService.deleteComment(questionId, commentId);
+        return Response.ok().build();
+    }
+
+}

--- a/src/main/java/br/usp/esimulados/resource/generated/ExamAttempts.java
+++ b/src/main/java/br/usp/esimulados/resource/generated/ExamAttempts.java
@@ -1,0 +1,14 @@
+package br.usp.esimulados.resource.generated;
+
+import br.usp.esimulados.model.exam.ExamAttempt;
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
+import io.quarkus.rest.data.panache.MethodProperties;
+import io.quarkus.rest.data.panache.ResourceProperties;
+
+@ResourceProperties
+public interface ExamAttempts extends PanacheEntityResource<ExamAttempt, Long> {
+
+    @MethodProperties(exposed = false)
+    ExamAttempt add(ExamAttempt entity);
+
+}

--- a/src/main/java/br/usp/esimulados/resource/generated/Exams.java
+++ b/src/main/java/br/usp/esimulados/resource/generated/Exams.java
@@ -1,0 +1,16 @@
+package br.usp.esimulados.resource.generated;
+
+import br.usp.esimulados.model.exam.Exam;
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
+import io.quarkus.rest.data.panache.MethodProperties;
+import io.quarkus.rest.data.panache.ResourceProperties;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Tag(name = "Exams")
+@ResourceProperties
+public interface Exams extends PanacheEntityResource<Exam, Long> {
+
+    @MethodProperties(exposed = false)
+    Exam add(Exam entity);
+
+}

--- a/src/main/java/br/usp/esimulados/resource/generated/Questions.java
+++ b/src/main/java/br/usp/esimulados/resource/generated/Questions.java
@@ -1,0 +1,13 @@
+package br.usp.esimulados.resource.generated;
+
+import br.usp.esimulados.model.questions.Question;
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
+import io.quarkus.rest.data.panache.MethodProperties;
+import io.quarkus.rest.data.panache.ResourceProperties;
+
+@ResourceProperties
+public interface Questions extends PanacheEntityResource<Question, Long>  {
+
+    @MethodProperties(exposed = false)
+    Question add(Question entity);
+}

--- a/src/main/java/br/usp/esimulados/service/EntityMapper.java
+++ b/src/main/java/br/usp/esimulados/service/EntityMapper.java
@@ -1,0 +1,37 @@
+package br.usp.esimulados.service;
+
+import br.usp.esimulados.model.exam.Exam;
+import br.usp.esimulados.model.exam.ExamAttempt;
+import br.usp.esimulados.model.exam.dto.AttemptExamDTO;
+import br.usp.esimulados.model.exam.dto.CreateExamDTO;
+import br.usp.esimulados.model.questions.Comment;
+import br.usp.esimulados.model.questions.Question;
+import br.usp.esimulados.model.questions.dto.CreateCommentDTO;
+import br.usp.esimulados.model.questions.dto.CreateQuestionDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "cdi")
+public interface EntityMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "questions", ignore = true)
+    @Mapping(target = "active", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    Exam createExamToExam(CreateExamDTO createExam);
+
+    @Mapping(target = "comments", ignore = true)
+    Question createQuestionToQuestion(CreateQuestionDTO createQuestion);
+
+    @Mapping(target = "active", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    Comment createCommentToComment(CreateCommentDTO createComment);
+
+    @Mapping(target = "active", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "uuid", ignore = true)
+    ExamAttempt attemptExamToExamAttempt(AttemptExamDTO attemptExam);
+}

--- a/src/main/java/br/usp/esimulados/service/EntityMapper.java
+++ b/src/main/java/br/usp/esimulados/service/EntityMapper.java
@@ -6,10 +6,14 @@ import br.usp.esimulados.model.exam.dto.AttemptExamDTO;
 import br.usp.esimulados.model.exam.dto.CreateExamDTO;
 import br.usp.esimulados.model.questions.Comment;
 import br.usp.esimulados.model.questions.Question;
+import br.usp.esimulados.model.questions.QuestionAlternative;
 import br.usp.esimulados.model.questions.dto.CreateCommentDTO;
+import br.usp.esimulados.model.questions.dto.CreateQuestionAlternativeDTO;
 import br.usp.esimulados.model.questions.dto.CreateQuestionDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.List;
 
 @Mapper(componentModel = "cdi")
 public interface EntityMapper {
@@ -23,6 +27,11 @@ public interface EntityMapper {
 
     @Mapping(target = "comments", ignore = true)
     Question createQuestionToQuestion(CreateQuestionDTO createQuestion);
+
+    @Mapping(target = "uuid", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    QuestionAlternative createQuestionAlternativeToQuestionAlternative(CreateQuestionAlternativeDTO createQuestionAlternative);
 
     @Mapping(target = "active", ignore = true)
     @Mapping(target = "createdAt", ignore = true)

--- a/src/main/java/br/usp/esimulados/service/ExamAttemptsService.java
+++ b/src/main/java/br/usp/esimulados/service/ExamAttemptsService.java
@@ -1,0 +1,35 @@
+package br.usp.esimulados.service;
+
+import br.usp.esimulados.exception.ObjectNotFoundException;
+import br.usp.esimulados.model.exam.Exam;
+import br.usp.esimulados.model.exam.ExamAttempt;
+import br.usp.esimulados.model.exam.dto.AttemptExamDTO;
+import br.usp.esimulados.model.user.User;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ApplicationScoped
+@RequiredArgsConstructor
+public class ExamAttemptsService {
+
+    @Inject
+    EntityMapper entityMapper;
+
+    public ExamAttempt add(AttemptExamDTO attemptExam) {
+        if(Exam.findById(attemptExam.examId()) == null) {
+            throw new ObjectNotFoundException("Exam not found");
+        }
+
+        if(User.findById(attemptExam.userId()) == null) {
+            throw new ObjectNotFoundException("User not found");
+        }
+
+        ExamAttempt examAttempt = entityMapper.attemptExamToExamAttempt(attemptExam);
+        examAttempt.persist();
+        return examAttempt;
+    }
+
+}

--- a/src/main/java/br/usp/esimulados/service/ExamsService.java
+++ b/src/main/java/br/usp/esimulados/service/ExamsService.java
@@ -1,0 +1,33 @@
+package br.usp.esimulados.service;
+
+import br.usp.esimulados.model.exam.Exam;
+import br.usp.esimulados.model.exam.dto.CreateExamDTO;
+import br.usp.esimulados.model.questions.Question;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Slf4j
+@ApplicationScoped
+@RequiredArgsConstructor
+public class ExamsService {
+
+    @Inject
+    EntityMapper entityMapper;
+
+    public Exam createExam(CreateExamDTO createExam) {
+        Exam exam = entityMapper.createExamToExam(createExam);
+
+        List<Question> questions = Question.list("id in ?1", createExam.questionIds());
+        exam.setQuestions(questions);
+
+        log.info("Creating exam: {}", exam);
+        exam.persist();
+
+        return exam;
+    }
+
+}

--- a/src/main/java/br/usp/esimulados/service/QuestionsService.java
+++ b/src/main/java/br/usp/esimulados/service/QuestionsService.java
@@ -3,7 +3,10 @@ package br.usp.esimulados.service;
 import br.usp.esimulados.exception.ObjectNotFoundException;
 import br.usp.esimulados.model.questions.Comment;
 import br.usp.esimulados.model.questions.Question;
+import br.usp.esimulados.model.questions.QuestionAlternative;
+import br.usp.esimulados.model.questions.QuestionHistory;
 import br.usp.esimulados.model.questions.dto.CreateCommentDTO;
+import br.usp.esimulados.model.questions.dto.CreateQuestionAlternativeDTO;
 import br.usp.esimulados.model.questions.dto.CreateQuestionDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -14,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @ApplicationScoped
@@ -25,6 +29,15 @@ public class QuestionsService {
 
     public Question createQuestion(CreateQuestionDTO newQuestion) {
         Question question = entityMapper.createQuestionToQuestion(newQuestion);
+
+        // Mapeamento manual das alternativas
+        List<QuestionAlternative> alternatives = newQuestion.questionAlternatives()
+                .stream()
+                .map(entityMapper::createQuestionAlternativeToQuestionAlternative)
+                .collect(Collectors.toList());
+
+        question.setAlternatives(alternatives);
+
         log.info("Creating question: {}", question);
         question.persist();
         return question;

--- a/src/main/java/br/usp/esimulados/service/QuestionsService.java
+++ b/src/main/java/br/usp/esimulados/service/QuestionsService.java
@@ -1,0 +1,61 @@
+package br.usp.esimulados.service;
+
+import br.usp.esimulados.exception.ObjectNotFoundException;
+import br.usp.esimulados.model.questions.Comment;
+import br.usp.esimulados.model.questions.Question;
+import br.usp.esimulados.model.questions.dto.CreateCommentDTO;
+import br.usp.esimulados.model.questions.dto.CreateQuestionDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@ApplicationScoped
+@RequiredArgsConstructor
+public class QuestionsService {
+
+    @Inject
+    EntityMapper entityMapper;
+
+    public Question createQuestion(CreateQuestionDTO newQuestion) {
+        Question question = entityMapper.createQuestionToQuestion(newQuestion);
+        log.info("Creating question: {}", question);
+        question.persist();
+        return question;
+    }
+
+    public void addComment(Long questionId, CreateCommentDTO newComment) {
+        Question question = Optional
+                .ofNullable((Question) Question.findById(questionId))
+                .orElseThrow(() -> new ObjectNotFoundException("Question not found"));
+
+        Comment comment = entityMapper.createCommentToComment(newComment);
+        List<Comment> questionComments = question.getComments();
+        questionComments.add(comment);
+        question.setUpdatedAt(LocalDateTime.now());
+    }
+
+    public void deleteComment(Long questionId, UUID commentId) {
+
+        Question question = Optional
+                .ofNullable((Question) Question.findById(questionId))
+                .orElseThrow(() -> new ObjectNotFoundException("Question not found"));
+
+        Comment comment = question
+                .getComments()
+                .stream()
+                .filter(commentCandidate -> commentCandidate.getUuid().equals(commentId))
+                .findFirst()
+                .orElseThrow(() -> new ObjectNotFoundException("Comment not found"));
+
+        question.getComments().remove(comment);
+        question.setUpdatedAt(LocalDateTime.now());
+
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,53 @@
+quarkus:
+  console:
+    color: true
+  hibernate-orm:
+    physical-naming-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+    database:
+      generation: none
+  http:
+    proxy:
+      allow-forwarded: true
+      enable-forwarded-host: true
+    port: ${PORT:8080}
+    cors:
+      ~: true
+      headers: accept, authorization, content-type, x-requested-with
+      methods: GET, OPTIONS, POST, DELETE, PATCH, PUT
+  smallrye-openapi:
+    info-license-url: https://www.apache.org/licenses/LICENSE-2.0.html
+    info-version: 1.0.1
+    info-contact-email: vsviniciuslima@gmail.com
+    info-contact-url: https://vsviniciuslima.dev/contact
+    info-license-name: Apache 2.0
+    info-title: E-Simulados
+    info-description: Plataforma de simulados
+    info-terms-of-service: Your terms here
+    info-contact-name: Vinicius Santana
+'%test':
+  quarkus:
+    datasource:
+      db-kind: h2
+'%dev':
+  quarkus:
+    hibernate-orm:
+      database:
+        generation: drop-and-create
+    datasource:
+      db-kind: postgresql
+    http:
+      cors:
+        origins: http://localhost:3000
+    live-reload:
+      instrumentation: true
+'%prod':
+  quarkus:
+    datasource:
+      db-kind: postgresql
+      username: ${APP_DB_USER}
+      password: ${APP_DB_PASSWORD}
+      jdbc:
+        url: ${APP_DB_HOST}
+    http:
+      cors:
+        origins: ${APP_CORS_ORIGIN}


### PR DESCRIPTION
## O que foi feito:
- [x] Adição da classe QuestionHistory para representar o histórico de cada questão.
- [x] Fix do bug em que as alternativas não estavam sendo mapeadas corretamente, fazendo com que o campo "alternatives" ficasse como `null`.
  - QuestionAlternative passou a ser uma Class ao invés de um Record para que seja possível criar e armazenar um UUID para ela.
  - Foi criado o método `createQuestionAlternativeToQuestionAlternative()` no EntityMapper para fazer o mapeamento.
- [x] Fix do bug em que a dificuldade da questão não estava sendo mapeada corretamente, fazendo com que o campo "difficulty" ficasse como `null`.