### PR TITLE
feat: implementa mapeamento do histórico da questão

### DIFF
--- a/src/main/java/br/usp/esimulados/model/questions/Question.java
+++ b/src/main/java/br/usp/esimulados/model/questions/Question.java
@@ -39,11 +39,15 @@ public class Question extends PanacheEntity {
     @Column(name = "comments", columnDefinition = "jsonb"/*, insertable = false, updatable = false*/)
     private List<Comment> comments;
 
-    private QuestionDifficulty difficulty; // EASY, MEDIUM, HARD
+    private QuestionDifficulty questionDifficulty; // EASY, MEDIUM, HARD
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "alternatives", columnDefinition = "jsonb"/*, insertable = false, updatable = false*/)
     private List<QuestionAlternative> alternatives;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "questionHistory", columnDefinition = "jsonb")
+    private QuestionHistory questionHistory = new QuestionHistory();
 
     private UUID uuid = UUID.randomUUID();
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/src/main/java/br/usp/esimulados/model/questions/QuestionDifficulty.java
+++ b/src/main/java/br/usp/esimulados/model/questions/QuestionDifficulty.java
@@ -1,5 +1,7 @@
 package br.usp.esimulados.model.questions;
 
 public enum QuestionDifficulty {
-    EASY, MEDIUM, HARD
+    EASY,
+    MEDIUM,
+    HARD
 }

--- a/src/main/java/br/usp/esimulados/model/questions/QuestionHistory.java
+++ b/src/main/java/br/usp/esimulados/model/questions/QuestionHistory.java
@@ -8,20 +8,18 @@ import lombok.Setter;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class QuestionAlternative implements Serializable {
+public class QuestionHistory implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private List<String> imageUrls;
-    private String content;
-    private boolean correct;
+    private Long attemptCount = 0L;
+    private Long correctAnswersCount = 0L;
 
     private UUID uuid = UUID.randomUUID();
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/src/main/java/br/usp/esimulados/resource/QuestionsResource.java
+++ b/src/main/java/br/usp/esimulados/resource/QuestionsResource.java
@@ -35,8 +35,8 @@ public class QuestionsResource {
     @Inject
     HttpServerRequest request;
 
-    @Transactional
     @POST
+    @Transactional
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Criar questão")
     @APIResponse(description = "Questão criada",
@@ -49,7 +49,7 @@ public class QuestionsResource {
                     ))
             })
     public Response createQuestion(
-           @Valid @RequestBody(description = "Lista de presentes a serem criados") CreateQuestionDTO createQuestion
+           @Valid @RequestBody(description = "Questão a ser criada") CreateQuestionDTO createQuestion
     ) {
         log.info("Request: {}", request.toString());
         return Response.ok(questionsService.createQuestion(createQuestion)).build();

--- a/src/main/java/br/usp/esimulados/service/EntityMapper.java
+++ b/src/main/java/br/usp/esimulados/service/EntityMapper.java
@@ -6,10 +6,14 @@ import br.usp.esimulados.model.exam.dto.AttemptExamDTO;
 import br.usp.esimulados.model.exam.dto.CreateExamDTO;
 import br.usp.esimulados.model.questions.Comment;
 import br.usp.esimulados.model.questions.Question;
+import br.usp.esimulados.model.questions.QuestionAlternative;
 import br.usp.esimulados.model.questions.dto.CreateCommentDTO;
+import br.usp.esimulados.model.questions.dto.CreateQuestionAlternativeDTO;
 import br.usp.esimulados.model.questions.dto.CreateQuestionDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.List;
 
 @Mapper(componentModel = "cdi")
 public interface EntityMapper {
@@ -23,6 +27,11 @@ public interface EntityMapper {
 
     @Mapping(target = "comments", ignore = true)
     Question createQuestionToQuestion(CreateQuestionDTO createQuestion);
+
+    @Mapping(target = "uuid", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    QuestionAlternative createQuestionAlternativeToQuestionAlternative(CreateQuestionAlternativeDTO createQuestionAlternative);
 
     @Mapping(target = "active", ignore = true)
     @Mapping(target = "createdAt", ignore = true)

--- a/src/main/java/br/usp/esimulados/service/QuestionsService.java
+++ b/src/main/java/br/usp/esimulados/service/QuestionsService.java
@@ -3,7 +3,10 @@ package br.usp.esimulados.service;
 import br.usp.esimulados.exception.ObjectNotFoundException;
 import br.usp.esimulados.model.questions.Comment;
 import br.usp.esimulados.model.questions.Question;
+import br.usp.esimulados.model.questions.QuestionAlternative;
+import br.usp.esimulados.model.questions.QuestionHistory;
 import br.usp.esimulados.model.questions.dto.CreateCommentDTO;
+import br.usp.esimulados.model.questions.dto.CreateQuestionAlternativeDTO;
 import br.usp.esimulados.model.questions.dto.CreateQuestionDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -14,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @ApplicationScoped
@@ -25,6 +29,15 @@ public class QuestionsService {
 
     public Question createQuestion(CreateQuestionDTO newQuestion) {
         Question question = entityMapper.createQuestionToQuestion(newQuestion);
+
+        // Mapeamento manual das alternativas
+        List<QuestionAlternative> alternatives = newQuestion.questionAlternatives()
+                .stream()
+                .map(entityMapper::createQuestionAlternativeToQuestionAlternative)
+                .collect(Collectors.toList());
+
+        question.setAlternatives(alternatives);
+
         log.info("Creating question: {}", question);
         question.persist();
         return question;


### PR DESCRIPTION
## O que foi feito:
- [x] Adição da classe QuestionHistory para representar o histórico de cada questão.
- [x] Fix do bug em que as alternativas não estavam sendo mapeadas corretamente, fazendo com que o campo "alternatives" ficasse como `null`.
  - QuestionAlternative passou a ser uma Class ao invés de um Record para que seja possível criar e armazenar um UUID para ela.
  - Foi criado o método `createQuestionAlternativeToQuestionAlternative()` no EntityMapper para fazer o mapeamento.
- [x] Fix do bug em que a dificuldade da questão não estava sendo mapeada corretamente, fazendo com que o campo "difficulty" ficasse como `null`.
